### PR TITLE
Add a check to enable or not if there is a DrupalImage

### DIFF
--- a/src/Plugin/CKEditorPlugin/EditorAdvancedImage.php
+++ b/src/Plugin/CKEditorPlugin/EditorAdvancedImage.php
@@ -89,7 +89,29 @@ class EditorAdvancedImage extends PluginBase implements CKEditorPluginInterface,
    * {@inheritdoc}
    */
   public function isEnabled(Editor $editor) {
-    return TRUE;
+    // Check if DrupalImage exist.
+    $settings = $editor->getSettings();
+
+    if($this->checkImageEnable($settings["toolbar"]['rows'][0])) {
+      return TRUE;
+    }
+    return FALSE;
+  }
+
+  /**
+   * Check if DrupalImage exist.
+   * @param $list
+   * @return bool
+   */
+  public function checkImageEnable($list) {
+    foreach($list as $items) {
+      foreach ($items["items"] as $item) {
+        if ('DrupalImage' === $item) {
+          return TRUE;
+        }
+      }
+    }
+    return FALSE;
   }
 
 }

--- a/src/Plugin/CKEditorPlugin/EditorAdvancedImage.php
+++ b/src/Plugin/CKEditorPlugin/EditorAdvancedImage.php
@@ -89,7 +89,7 @@ class EditorAdvancedImage extends PluginBase implements CKEditorPluginInterface,
    * {@inheritdoc}
    */
   public function isEnabled(Editor $editor) {
-    // Check if DrupalImage exist.
+    // Check if a DrupalImage exist.
     $settings = $editor->getSettings();
 
     if($this->checkImageEnable($settings["toolbar"]['rows'][0])) {
@@ -99,7 +99,8 @@ class EditorAdvancedImage extends PluginBase implements CKEditorPluginInterface,
   }
 
   /**
-   * Check if DrupalImage exist.
+   * Check if a DrupalImage exist.
+   * 
    * @param $list
    * @return bool
    */


### PR DESCRIPTION
**Problem/Motivation**

- When I have no image in a ckeditor, the ckeditor does not works.
<img width="1377" alt="50905335-dfeff780-1422-11e9-9e53-55806ec75c9e" src="https://user-images.githubusercontent.com/7878654/50917402-b7c1c200-143d-11e9-974c-9efa9fee59f2.png">


**Proposed resolution**

- Add a check to enable or not the module for the corresponding ckeditor

**Completed tasks**

**Remaining tasks**

- I think is not a good way to have a double foreach (but it's in a big array). May be you now an elegant way to find a value in a big multidimensionnal array when you don't now the corresponding key.
