### PR TITLE
replace drupal_ti by wengerk/docker-drupal-for-contrib

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,32 @@
+language: php
+
+services:
+  - docker
+
+env:
+  global:
+    # The module name to be mounted and tested in the Docker.
+    - MODULE_NAME="editor_advanced_image"
+
+matrix:
+  include:
+    - name: Drupal 8.8.x
+      env: BASE_IMAGE_TAG="8.8"
+    - name: Drupal 8.9.x
+      env: BASE_IMAGE_TAG="8.9"
+    - name: Drupal 9.0.x
+      env: BASE_IMAGE_TAG="9.0"
+
+before_install:
+  - docker-compose build --pull --build-arg BASE_IMAGE_TAG=${BASE_IMAGE_TAG} drupal
+  - docker-compose up -d drupal chrome
+  # wait on Docker to be ready, especially MariaDB that takes many seconds to be up.
+  - docker-compose exec drupal wait-for-it drupal:80 -t 60
+  - docker-compose exec drupal wait-for-it db:3306 -t 60
+  - docker-compose exec drupal wait-for-it chrome:9515 -t 60
+
+before_script:
+  - docker-compose exec -u www-data drupal drush site-install standard --db-url="mysql://drupal:drupal@db/drupal" -y
+
+script:
+  - docker-compose exec -u www-data drupal phpunit --no-coverage --group=${MODULE_NAME}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ CHANGELOG
 
 ## NEXT RELEASE
  - close #3045122 - fix Drupal-CI Composer failure since Drupal 8.7.x+ - Update of drupal/coder squizlabs/php_codesniffer"
+ - replace drupal_ti by wengerk/docker-drupal-for-contrib
+ - ensure compatibility with Drupal 8.8+
+ - ensure compatibility with Drupal 9
 
 ## 8.x-1.0-beta5 (2018-11-29)
  - fix #2987982 - Classes not saving on captioned images

--- a/DEVELOPPING.md
+++ b/DEVELOPPING.md
@@ -25,57 +25,29 @@ on your environment:
 
   * drush
   * Latest dev release of Drupal 8.x.
+  * docker
+  * docker-compose
+
+### Project bootstrap
+
+Once run, you will be able to access to your fresh installed Drupal on `localhost::8888`.
+
+    docker-compose build --pull --build-arg BASE_IMAGE_TAG=8.9 drupal
+    (get a coffee, this will take some time...)
+    docker-compose up -d drupal chrome
+    docker-compose exec -u www-data drupal drush site-install standard --db-url="mysql://drupal:drupal@db/drupal" -y
+    
+    # You may be interesed by reseting the admin passowrd of your Docker and install the module using those cmd.
+    docker-compose exec drupal drush user:password admin admin
+    docker-compose exec drupal drush en editor_advanced_image
 
 ## 🏆 Tests
 
-Editor Advanced Image use WebDriverTestBase to test
-Javascript web-based behaviors and interactions.
+We use the [Docker for Drupal Contrib images](https://hub.docker.com/r/wengerk/drupal-for-contrib) to run testing on our project.
 
-For tests you need a working database connection and for browser tests
-your Drupal installation needs to be reachable via a web server.
-Copy the phpunit config file:
+Run testing by stopping at first failure using the following command:
 
-  ```bash
-  $ cd core
-  $ cp phpunit.xml.dist phpunit.xml
-  ```
-
-You must provide `SIMPLETEST_BASE_URL`, Eg. `http://localhost`.
-You must provide `SIMPLETEST_DB`,
-Eg. `sqlite://localhost/build/editor_advanced_image.sqlite`.
-
-Start PhantomJS:
-
-  ```bash
-  phantomjs --ssl-protocol=any --ignore-ssl-errors=true \
-  vendor/jcalderonzumba/gastonjs/src/Client/main.js 8510 1024 768&
-  ```
-
-Run the javascript functional tests:
-
-  ```bash
-  # You must be on the drupal-root folder - usually /web.
-  $ cd web
-  $ SIMPLETEST_DB="sqlite://localhost//tmp/editor_advanced_image.sqlite" \
-  SIMPLETEST_BASE_URL='http://d8.dev' \
-  ../vendor/bin/phpunit -c core --testsuite functional-javascript \
-  --group editor_advanced_image
-  ```
-
-Debug using
-
-  ```bash
-  # You must be on the drupal-root folder - usually /web.
-  $ cd web
-  $ SIMPLETEST_DB="sqlite://localhost//tmp/editor_advanced_image.sqlite" \
-  SIMPLETEST_BASE_URL='http://d8.dev' \
-  ../vendor/bin/phpunit -c core --testsuite functional-javascript \
-  --group editor_advanced_image \
-  --printer="\Drupal\Tests\Listeners\HtmlOutputPrinter" --stop-on-error
-  ```
-
-You must provide a `BROWSERTEST_OUTPUT_DIRECTORY`,
-Eg. `/path/to/webroot/sites/simpletest/browser_output`.
+    docker-compose exec -u www-data drupal phpunit --group=editor_advanced_image --no-coverage --stop-on-failure
 
 ## 🚔 Check Javascript best practices
 

--- a/DEVELOPPING.md
+++ b/DEVELOPPING.md
@@ -15,7 +15,7 @@ Drupal repo
 
 Github repo
   ```
-  git remote add github https://github.com/antistatique/drupal-editor-advanced-image.git
+  git remote add github git@github.com:antistatique/drupal-editor-advanced-image.git
   ```
 
 ## 🔧 Prerequisites

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,2 @@
+ARG BASE_IMAGE_TAG=8.9
+FROM wengerk/drupal-for-contrib:${BASE_IMAGE_TAG}

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ must upgrade to `8.x-2.x` version of **Editor Advanced Image**.
 
 ## Which version should I use?
 
-|Drupal Core|NBSP        |
+|Drupal Core|EAI         |
 |:---------:|:----------:|
 |8.7.x      |1.x         |
 |8.8.x      |2.x         |

--- a/README.md
+++ b/README.md
@@ -29,15 +29,22 @@ By using Editor Advanced Image, you will also be able to:
 
 ## Versions
 
-Editor Advanced Image is only available for Drupal 8 !
-The module is ready to be used in Drupal 8, there are no known issues.
+The version `8.x-1.x` is not compatible with Drupal `8.8.x`.
 
-This version should work with all Drupal 8 releases, and it is always
-recommended to keep Drupal core installations up to date.
+Drupal `8.8.x` brings some breaking change with tests and so you
+must upgrade to `8.x-2.x` version of **Editor Advanced Image**.
+
+## Which version should I use?
+
+|Drupal Core|NBSP        |
+|:---------:|:----------:|
+|8.7.x      |1.x         |
+|8.8.x      |2.x         |
+|9.x        |2.x         |
 
 ## Dependencies
 
-The Drupal 8 version of Editor Advanced Image requires nothing !
+The Drupal 8 & Drupal 9 version of Editor Advanced Image requires nothing !
 Feel free to use it.
 
 ## Supporting organizations

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,45 @@
+version: '3.6'
+
+services:
+
+  drupal:
+    build: .
+    depends_on:
+      - db
+    ports:
+      - 8888:80
+    volumes:
+      # Mount the module in the proper contrib module directory.
+      - .:/var/www/html/modules/contrib/editor_advanced_image
+    restart: always
+
+  db:
+    image: mariadb:10.3.7
+    environment:
+      MYSQL_USER: drupal
+      MYSQL_PASSWORD: drupal
+      MYSQL_DATABASE: drupal
+      MYSQL_ROOT_PASSWORD: root
+    restart: always
+
+  chrome:
+    image: drupalci/webdriver-chromedriver:production
+    depends_on:
+      - drupal
+    ulimits:
+      core:
+        soft: -1
+        hard: -1
+    cap_add:
+      - SYS_ADMIN
+    ports:
+      - "4444:4444"
+      - "9515:9515"
+    volumes:
+      - /dev/shm:/dev/shm
+    entrypoint:
+      - chromedriver
+      - "--no-sandbox"
+      - "--log-path=/tmp/chromedriver.log"
+      - "--verbose"
+      - "--whitelisted-ips="

--- a/editor_advanced_image.info.yml
+++ b/editor_advanced_image.info.yml
@@ -1,7 +1,7 @@
 name: 'Editor Advanced Image'
 type: module
 description: 'Enhances the inline-image Dialog in D8 CKEditor.'
-core: 8.x
+core_version_requirement: ^8.8 || ^9
 package: CKEditor
 
 dependencies:

--- a/tests/src/FunctionalJavascript/UiDialogTest.php
+++ b/tests/src/FunctionalJavascript/UiDialogTest.php
@@ -318,7 +318,7 @@ class UiDialogTest extends UiTestBase {
     $this->getSession()->switchToIFrame('ckeditor');
 
     $assert_session = $this->assertSession();
-    $this->assertTrue($assert_session->waitForElementVisible('css', '.cke_editable', 1000));
+    $this->assertNotEmpty($assert_session->waitForElementVisible('css', '.cke_editable', 1000));
   }
 
 }

--- a/tests/src/FunctionalJavascript/UiTestBase.php
+++ b/tests/src/FunctionalJavascript/UiTestBase.php
@@ -11,6 +11,11 @@ use Behat\Mink\Exception\ElementNotFoundException;
 abstract class UiTestBase extends WebDriverTestBase {
 
   /**
+   * {@inheritdoc}
+   */
+  protected $defaultTheme = 'classy';
+
+  /**
    * Finds field (input, textarea, select) with specified locator.
    *
    * @param string $locator


### PR DESCRIPTION
 - close #3045122 - fix Drupal-CI Composer failure since Drupal 8.7.x+ - Update of drupal/coder squizlabs/php_codesniffer"
 - replace drupal_ti by wengerk/docker-drupal-for-contrib
 - ensure compatibility with Drupal 8.8+
 - ensure compatibility with Drupal 9