### PR TITLE
add official stable support for drupal 10.4 & 11.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,7 @@ jobs:
         run: docker compose exec -T drupal wait-for-it db:3306 -t 60
       - name: Run unit tests
         run: docker compose -f docker-compose.yml exec -T -u www-data drupal phpunit --testdox --no-coverage --group=${{ matrix.module }} --exclude-group=${{ matrix.module }}_functional --configuration=/var/www/html/phpunit.xml
+        continue-on-error: ${{ matrix.experimental }}
 
   tests-functional:
     name: Functional Tests
@@ -70,6 +71,7 @@ jobs:
         run: docker compose -f docker-compose.yml exec -T -u www-data drupal drush site-install standard --db-url="mysql://drupal:drupal@db/drupal" -y
       - name: Run tests
         run: docker compose -f docker-compose.yml exec -T -u www-data drupal phpunit --testdox --no-coverage --group=${{ matrix.module }}_functional --configuration=/var/www/html/phpunit.xml --fail-on-risky
+        continue-on-error: ${{ matrix.experimental }}
 
   upgrade-status:
     name: Upgrade Status

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,16 @@ jobs:
 
     strategy:
       matrix:
-        drupal_version: ['10.0', '10.1', '10.2', '11.0']
+        drupal_version: ['10.0', '10.1', '10.2', '10.3', '10.4', '11.0', '11.1']
         module: ['editor_advanced_image']
+        experimental: [ false ]
+        include:
+          - drupal_version: '10.5'
+            module: 'editor_advanced_image'
+            experimental: true
+          - drupal_version: '11.2'
+            module: 'editor_advanced_image'
+            experimental: true
 
     steps:
       - uses: actions/checkout@v4
@@ -34,8 +42,16 @@ jobs:
 
     strategy:
       matrix:
-        drupal_version: ['10.0', '10.1', '10.2']
+        drupal_version: ['10.0', '10.1', '10.2', '10.3', '10.4', '11.0', '11.1']
         module: ['editor_advanced_image']
+        experimental: [ false ]
+        include:
+          - drupal_version: '10.5'
+            module: 'editor_advanced_image'
+            experimental: true
+          - drupal_version: '11.2'
+            module: 'editor_advanced_image'
+            experimental: true
 
     steps:
       - uses: actions/checkout@v4
@@ -61,7 +77,7 @@ jobs:
 
     strategy:
       matrix:
-        drupal_version: ['10.2']
+        drupal_version: ['10.4']
         module: ['editor_advanced_image']
 
     steps:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -34,7 +34,7 @@ variables:
   # Opt in to testing previous & next minor (Drupal 10.0.x and 10.2.x).
   OPT_IN_TEST_PREVIOUS_MINOR: '1'
   OPT_IN_TEST_NEXT_MINOR: '1'
-  # The 3.x branch of the CDN module requires Drupal 10.x minimum.
+  # The 3.x branch of the module requires Drupal 10.x minimum.
   CORE_PREVIOUS_PHP_MIN: '8.1'
   # Opt in to testing $CORE_MAJOR_DEVELOPMENT (currently Drupal 11).
   OPT_IN_TEST_NEXT_MAJOR: '1'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - pass all dataprovider phpunit to static methods
 
+### Removed
+- remove legacy version annotation on docker-compose.yml
+
 ## [3.0.0] - 2024-05-03
 ### Removed
 - drop support of drupal 9.x

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - pass all dataprovider phpunit to static methods
+- update Docker MariaDB 10.3 -> 10.6
 
 ### Removed
 - remove legacy version annotation on docker-compose.yml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - add official support of drupal 10.4
 - add official support of drupal 11.1
 
+### Changed
+- pass all dataprovider phpunit to static methods
+
 ## [3.0.0] - 2024-05-03
 ### Removed
 - drop support of drupal 9.x

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- add official support of drupal 10.4
+- add official support of drupal 11.1
 
 ## [3.0.0] - 2024-05-03
 ### Removed

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.6'
-
 services:
   drupal:
     build: .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     restart: always
 
   db:
-    image: mariadb:10.3.8
+    image: mariadb:10.6
     environment:
       MYSQL_USER: drupal
       MYSQL_PASSWORD: drupal

--- a/tests/src/FunctionalJavascript/CKEditor5EditorAdvancedImageDialogTest.php
+++ b/tests/src/FunctionalJavascript/CKEditor5EditorAdvancedImageDialogTest.php
@@ -311,7 +311,7 @@ class CKEditor5EditorAdvancedImageDialogTest extends WebDriverTestBase {
   /**
    * A collection of attribute to enable and ensure works when enabled.
    */
-  public function providerAttributesTest(): iterable {
+  public static function providerAttributesTest(): iterable {
     return [
       '<img title>' => [
         'attribute_name' => 'title',

--- a/tests/src/Unit/CKEditor5EditorAdvancedImagePluginTest.php
+++ b/tests/src/Unit/CKEditor5EditorAdvancedImagePluginTest.php
@@ -40,7 +40,7 @@ class CKEditor5EditorAdvancedImagePluginTest extends UnitTestCase {
   /**
    * Provides a list of configs to test providerGetDynamicPluginConfig.
    */
-  public function providerGetDynamicPluginConfig(): array {
+  public static function providerGetDynamicPluginConfig(): array {
     return [
       'Default configuration' => [
         EditorAdvancedImage::DEFAULT_CONFIGURATION,
@@ -220,7 +220,7 @@ class CKEditor5EditorAdvancedImagePluginTest extends UnitTestCase {
   /**
    * Provides a list of configs to test getElementsSubset.
    */
-  public function providerGetElementsSubset(): iterable {
+  public static function providerGetElementsSubset(): iterable {
     return [
       'Default configuration' => [
         EditorAdvancedImage::DEFAULT_CONFIGURATION,
@@ -301,7 +301,7 @@ class CKEditor5EditorAdvancedImagePluginTest extends UnitTestCase {
   /**
    * Provides a list of configs to test getAllowedStringForSupportedAttribute.
    */
-  public function providerGetAllowedStringForSupportedAttribute(): iterable {
+  public static function providerGetAllowedStringForSupportedAttribute(): iterable {
     yield ['', NULL, \OutOfBoundsException::class];
     yield ['foo', NULL, \OutOfBoundsException::class];
     yield ['foo bar', NULL, \OutOfBoundsException::class];
@@ -328,7 +328,7 @@ class CKEditor5EditorAdvancedImagePluginTest extends UnitTestCase {
   /**
    * Provides a list of configs to test getAllowedHtmlForSupportedAttribute.
    */
-  public function providerGetAllowedHtmlForSupportedAttribute(): iterable {
+  public static function providerGetAllowedHtmlForSupportedAttribute(): iterable {
     yield ['', NULL, \OutOfBoundsException::class];
     yield ['foo', NULL, \OutOfBoundsException::class];
     yield ['foo bar', NULL, \OutOfBoundsException::class];


### PR DESCRIPTION
### 💬 Description
add official stable support for drupal 10.4 & 11.1

- [x] Update the "Unreleased" section of the `CHANGELOG.md` with [chan](https://github.com/geut/chan/tree/main/packages/chan)
