### PR TITLE
change gitlab-ci in order to run tests for Drupal 9.5.x to 10.2 but not for Drupal 10.3+

### DIFF
--- a/.cspell-project-words.txt
+++ b/.cspell-project-words.txt
@@ -37,3 +37,5 @@ viewcollection
 visibilit
 wapmorgan
 wengerk
+phpmd
+tokenizes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,16 @@ jobs:
 
     strategy:
       matrix:
-        drupal_version: ['9.5', '10.0', '10.1', '10.2', '10.3', '10.4']
+        drupal_version: ['9.5', '10.0', '10.1', '10.2']
         module: ['editor_advanced_image']
         experimental: [ false ]
         include:
+          - drupal_version: '10.3'
+            module: 'editor_advanced_image'
+            experimental: true
+          - drupal_version: '10.4'
+            module: 'editor_advanced_image'
+            experimental: true
           - drupal_version: '10.5'
             module: 'editor_advanced_image'
             experimental: true
@@ -40,10 +46,16 @@ jobs:
 
     strategy:
       matrix:
-        drupal_version: ['9.5', '10.0', '10.1', '10.2', '10.3', '10.4']
+        drupal_version: ['9.5', '10.0', '10.1', '10.2']
         module: ['editor_advanced_image']
         experimental: [ false ]
         include:
+          - drupal_version: '10.3'
+            module: 'editor_advanced_image'
+            experimental: true
+          - drupal_version: '10.4'
+            module: 'editor_advanced_image'
+            experimental: true
           - drupal_version: '10.5'
             module: 'editor_advanced_image'
             experimental: true
@@ -75,6 +87,7 @@ jobs:
       matrix:
         drupal_version: ['9.5']
         module: ['editor_advanced_image']
+        experimental: [ true ]
 
     steps:
       - uses: actions/checkout@v4
@@ -95,3 +108,4 @@ jobs:
         run: docker compose exec -T drupal wait-for-it db:3306 -- ./vendor/bin/drush en ${{ matrix.module }} -y
       - name: Run upgrade status
         run: docker compose exec -T drupal wait-for-it db:3306 -- ./vendor/bin/drush upgrade_status:analyze ${{ matrix.module }}
+        continue-on-error: ${{ matrix.experimental }}

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -29,12 +29,27 @@ include:
 # Docs at https://git.drupalcode.org/project/gitlab_templates/-/blob/1.0.x/includes/include.drupalci.variables.yml
 ################
 variables:
-  # Opt in to testing current minor against max supported PHP version.
-  OPT_IN_TEST_MAX_PHP: '1'
-  # Opt in to testing previous (Drupal 10.1.x).
-  OPT_IN_TEST_PREVIOUS_MINOR: '1'
-  # The 4.x branch of the CDN module requires PHP >=8.1, rather than core's >=7.4.
+  # The 2.x branch of the module should run on 9.5 to maximum 10.2 but not upper.
+  CORE_PREVIOUS_STABLE: '10.0'
+  CORE_STABLE: '10.1'
+  CORE_NEXT_MINOR: '10.2'
+  CORE_SECURITY_PREVIOUS_MINOR: '10.1'
+  # The 2.x branch of the module requires PHP >=8.1, rather than core's >=7.4.
   CORE_PREVIOUS_PHP_MIN: '8.1'
+  CORE_PHP_MAX: '8.2'
+
+  # Opt-in to testing previous Minor (Drupal 10.x).
+  OPT_IN_TEST_CURRENT: '1'
+  # Opt-out to testing current minor against max supported PHP version.
+  OPT_IN_TEST_MAX_PHP: '0'
+  # Opt-in to testing previous (Drupal 10.3.x).
+  OPT_IN_TEST_PREVIOUS_MINOR: '1'
+  # Opt-in to testing previous Major (Drupal 9.5.x).
+  OPT_IN_TEST_PREVIOUS_MAJOR: '1'
+  # Opt-int of testing next Minor (Drupal 10.x).
+  OPT_IN_TEST_NEXT_MINOR: '1'
+  # Opt-out of testing next Major (Drupal 11.x).
+  OPT_IN_TEST_NEXT_MAJOR: '0'
 
 # This module wants to strictly comply with Drupal's coding standards.
 phpcs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-- add official support of drupal 10.4
+- fix support from 9.5.x to 10.2 maximum
 
 ### Removed
 - remove legacy version annotation on docker-compose.yml
+
+### Changed
+- change gitlab-ci in order to run tests for Drupal 9.5.x & 10.2.x but not for Drupal 10.3+
 
 ## [2.3.0] - 2024-04-08
 ### Fixed


### PR DESCRIPTION
### 💬 Description
change gitlab-ci in order to run tests for Drupal 9.5.x & 10.x but not for Drupal 11.x+

- [x] Update the "Unreleased" section of the `CHANGELOG.md` with [chan](https://github.com/geut/chan/tree/main/packages/chan)
