### PR TITLE
drop support Drupal 9.5, add official support 10.3.x+

### DIFF
--- a/.cspell-project-words.txt
+++ b/.cspell-project-words.txt
@@ -37,3 +37,5 @@ viewcollection
 visibilit
 wapmorgan
 wengerk
+phpmd
+tokenizes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,16 +11,10 @@ jobs:
 
     strategy:
       matrix:
-        drupal_version: ['9.5', '10.0', '10.1', '10.2']
+        drupal_version: ['10.3', '10.4']
         module: ['editor_advanced_image']
         experimental: [ false ]
         include:
-          - drupal_version: '10.3'
-            module: 'editor_advanced_image'
-            experimental: true
-          - drupal_version: '10.4'
-            module: 'editor_advanced_image'
-            experimental: true
           - drupal_version: '10.5'
             module: 'editor_advanced_image'
             experimental: true
@@ -46,16 +40,10 @@ jobs:
 
     strategy:
       matrix:
-        drupal_version: ['9.5', '10.0', '10.1', '10.2']
+        drupal_version: ['10.3', '10.4']
         module: ['editor_advanced_image']
         experimental: [ false ]
         include:
-          - drupal_version: '10.3'
-            module: 'editor_advanced_image'
-            experimental: true
-          - drupal_version: '10.4'
-            module: 'editor_advanced_image'
-            experimental: true
           - drupal_version: '10.5'
             module: 'editor_advanced_image'
             experimental: true
@@ -85,9 +73,8 @@ jobs:
 
     strategy:
       matrix:
-        drupal_version: ['9.5']
+        drupal_version: ['10.3']
         module: ['editor_advanced_image']
-        experimental: [ true ]
 
     steps:
       - uses: actions/checkout@v4
@@ -108,4 +95,3 @@ jobs:
         run: docker compose exec -T drupal wait-for-it db:3306 -- ./vendor/bin/drush en ${{ matrix.module }} -y
       - name: Run upgrade status
         run: docker compose exec -T drupal wait-for-it db:3306 -- ./vendor/bin/drush upgrade_status:analyze ${{ matrix.module }}
-        continue-on-error: ${{ matrix.experimental }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,16 @@ jobs:
 
     strategy:
       matrix:
-        drupal_version: ['9.5', '10.0', '10.1', '10.2', '10.3', '10.4']
+        drupal_version: ['9.5', '10.0', '10.1', '10.2']
         module: ['editor_advanced_image']
         experimental: [ false ]
         include:
+          - drupal_version: '10.3'
+            module: 'editor_advanced_image'
+            experimental: true
+          - drupal_version: '10.4'
+            module: 'editor_advanced_image'
+            experimental: true
           - drupal_version: '10.5'
             module: 'editor_advanced_image'
             experimental: true
@@ -40,10 +46,16 @@ jobs:
 
     strategy:
       matrix:
-        drupal_version: ['9.5', '10.0', '10.1', '10.2', '10.3', '10.4']
+        drupal_version: ['9.5', '10.0', '10.1', '10.2']
         module: ['editor_advanced_image']
         experimental: [ false ]
         include:
+          - drupal_version: '10.3'
+            module: 'editor_advanced_image'
+            experimental: true
+          - drupal_version: '10.4'
+            module: 'editor_advanced_image'
+            experimental: true
           - drupal_version: '10.5'
             module: 'editor_advanced_image'
             experimental: true
@@ -75,6 +87,7 @@ jobs:
       matrix:
         drupal_version: ['9.5']
         module: ['editor_advanced_image']
+        experimental: [ true ]
 
     steps:
       - uses: actions/checkout@v4
@@ -95,3 +108,4 @@ jobs:
         run: docker compose exec -T drupal wait-for-it db:3306 -- ./vendor/bin/drush en ${{ matrix.module }} -y
       - name: Run upgrade status
         run: docker compose exec -T drupal wait-for-it db:3306 -- ./vendor/bin/drush upgrade_status:analyze ${{ matrix.module }}
+        continue-on-error: ${{ matrix.experimental }}

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -29,12 +29,26 @@ include:
 # Docs at https://git.drupalcode.org/project/gitlab_templates/-/blob/1.0.x/includes/include.drupalci.variables.yml
 ################
 variables:
-  # Opt in to testing current minor against max supported PHP version.
-  OPT_IN_TEST_MAX_PHP: '1'
-  # Opt in to testing previous (Drupal 10.1.x).
-  OPT_IN_TEST_PREVIOUS_MINOR: '1'
-  # The 4.x branch of the CDN module requires PHP >=8.1, rather than core's >=7.4.
+  # The 2.x branch of the module should run on 9.5 to maximum 10.2 but not upper.
+  CORE_PREVIOUS_STABLE: '10.0'
+  CORE_STABLE: '10.1'
+  CORE_NEXT_MINOR: '10.2'
+  CORE_SECURITY_PREVIOUS_MINOR: '10.1'
+  # The 2.x branch of the module requires PHP >=8.1, rather than core's >=7.4.
   CORE_PREVIOUS_PHP_MIN: '8.1'
+
+  # Opt-in to testing previous Minor (Drupal 10.x).
+  OPT_IN_TEST_CURRENT: '1'
+  # Opt-out to testing current minor against max supported PHP version.
+  OPT_IN_TEST_MAX_PHP: '0'
+  # Opt-in to testing previous (Drupal 10.3.x).
+  OPT_IN_TEST_PREVIOUS_MINOR: '1'
+  # Opt-in to testing previous Major (Drupal 9.5.x).
+  OPT_IN_TEST_PREVIOUS_MAJOR: '1'
+  # Opt-int of testing next Minor (Drupal 10.x).
+  OPT_IN_TEST_NEXT_MINOR: '1'
+  # Opt-out of testing next Major (Drupal 11.x).
+  OPT_IN_TEST_NEXT_MAJOR: '0'
 
 # This module wants to strictly comply with Drupal's coding standards.
 phpcs:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -29,23 +29,23 @@ include:
 # Docs at https://git.drupalcode.org/project/gitlab_templates/-/blob/1.0.x/includes/include.drupalci.variables.yml
 ################
 variables:
-  # The 2.x branch of the module should run on 9.5 to maximum 10.2 but not upper.
-  CORE_PREVIOUS_STABLE: '10.0'
-  CORE_STABLE: '10.1'
-  CORE_NEXT_MINOR: '10.2'
-  CORE_SECURITY_PREVIOUS_MINOR: '10.1'
+  # The 2.x branch of the module should run on ^10.2 to maximum 10.x but not upper.
+  CORE_PREVIOUS_STABLE: '10.3'
+  CORE_STABLE: '10.4'
+  CORE_NEXT_MINOR: '10.5'
+  CORE_SECURITY_PREVIOUS_MINOR: '10.3'
   # The 2.x branch of the module requires PHP >=8.1, rather than core's >=7.4.
   CORE_PREVIOUS_PHP_MIN: '8.1'
 
-  # Opt-in to testing previous Minor (Drupal 10.x).
+  # Opt-in to testing current (Drupal 10.4).
   OPT_IN_TEST_CURRENT: '1'
-  # Opt-out to testing current minor against max supported PHP version.
-  OPT_IN_TEST_MAX_PHP: '0'
+  # Opt-in to testing current minor against max supported PHP version.
+  OPT_IN_TEST_MAX_PHP: '1'
   # Opt-in to testing previous (Drupal 10.3.x).
   OPT_IN_TEST_PREVIOUS_MINOR: '1'
-  # Opt-in to testing previous Major (Drupal 9.5.x).
-  OPT_IN_TEST_PREVIOUS_MAJOR: '1'
-  # Opt-int of testing next Minor (Drupal 10.x).
+  # Opt-out to testing previous Major (Drupal 9.5).
+  OPT_IN_TEST_PREVIOUS_MAJOR: '0'
+  # Opt-int of testing next Minor (Drupal 10.5).
   OPT_IN_TEST_NEXT_MINOR: '1'
   # Opt-out of testing next Major (Drupal 11.x).
   OPT_IN_TEST_NEXT_MAJOR: '0'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-- add official support of drupal 10.4
+- fix support from 9.5.x to 10.2 maximum
 
 ### Removed
 - remove legacy version annotation on docker-compose.yml
+
+### Changed
+- change gitlab-ci in order to run tests for Drupal 9.5.x & 10.2.x but not for Drupal 10.3+
 
 ## [2.3.0] - 2024-04-08
 ### Fixed

--- a/editor_advanced_image.info.yml
+++ b/editor_advanced_image.info.yml
@@ -1,7 +1,7 @@
 name: 'Editor Advanced Image'
 type: module
 description: 'Enhances the inline-image Dialog in D8 CKEditor.'
-core_version_requirement: ^9.5 || ~10.0.0 || ~10.1.0 || ~10.2.0
+core_version_requirement: ^10.3 || ^11.0
 package: CKEditor
 
 dependencies:

--- a/editor_advanced_image.info.yml
+++ b/editor_advanced_image.info.yml
@@ -1,7 +1,7 @@
 name: 'Editor Advanced Image'
 type: module
 description: 'Enhances the inline-image Dialog in D8 CKEditor.'
-core_version_requirement: ^9.5 || ^10
+core_version_requirement: ^9.5 || ~10.0.0 || ~10.1.0 || ~10.2.0
 package: CKEditor
 
 dependencies:

--- a/tests/src/Kernel/CKEditor4To5Upgrade/UpgradePathTest.php
+++ b/tests/src/Kernel/CKEditor4To5Upgrade/UpgradePathTest.php
@@ -135,7 +135,7 @@ class UpgradePathTest extends SmartDefaultSettingsTest {
   /**
    * {@inheritdoc}
    */
-  public function provider() {
+  public static function provider() {
     $expected_ckeditor5_toolbar = [
       'items' => [
         'bold',


### PR DESCRIPTION
### 💬 Description
drop support Drupal 9.5, add official support 10.3.x+

- [x] Update the "Unreleased" section of the `CHANGELOG.md` with [chan](https://github.com/geut/chan/tree/main/packages/chan)
