### PR TITLE
add official stable support for drupal 10.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,16 +11,10 @@ jobs:
 
     strategy:
       matrix:
-        drupal_version: ['9.5', '10.0', '10.1', '10.2']
+        drupal_version: ['9.5', '10.3', '10.4']
         module: ['editor_advanced_image']
         experimental: [ false ]
         include:
-          - drupal_version: '10.3'
-            module: 'editor_advanced_image'
-            experimental: true
-          - drupal_version: '10.4'
-            module: 'editor_advanced_image'
-            experimental: true
           - drupal_version: '10.5'
             module: 'editor_advanced_image'
             experimental: true
@@ -46,16 +40,10 @@ jobs:
 
     strategy:
       matrix:
-        drupal_version: ['9.5', '10.0', '10.1', '10.2']
+        drupal_version: ['9.5', '10.3', '10.4']
         module: ['editor_advanced_image']
         experimental: [ false ]
         include:
-          - drupal_version: '10.3'
-            module: 'editor_advanced_image'
-            experimental: true
-          - drupal_version: '10.4'
-            module: 'editor_advanced_image'
-            experimental: true
           - drupal_version: '10.5'
             module: 'editor_advanced_image'
             experimental: true
@@ -85,7 +73,7 @@ jobs:
 
     strategy:
       matrix:
-        drupal_version: ['9.5']
+        drupal_version: ['10.3']
         module: ['editor_advanced_image']
         experimental: [ true ]
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        drupal_version: ['9.5', '10.3', '10.4']
+        drupal_version: ['9.5', '10.0', '10.1', '10.2', '10.3', '10.4']
         module: ['editor_advanced_image']
         experimental: [ false ]
         include:
@@ -40,7 +40,7 @@ jobs:
 
     strategy:
       matrix:
-        drupal_version: ['9.5', '10.3', '10.4']
+        drupal_version: ['9.5', '10.0', '10.1', '10.2', '10.3', '10.4']
         module: ['editor_advanced_image']
         experimental: [ false ]
         include:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -45,7 +45,7 @@ variables:
   OPT_IN_TEST_PREVIOUS_MINOR: '1'
   # Opt-in to testing previous Major (Drupal 9.5.x).
   OPT_IN_TEST_PREVIOUS_MAJOR: '1'
-  # Opt-int of testing next Minor (Drupal 10.5).
+  # Opt-out of testing next Minor (Drupal 10.5).
   OPT_IN_TEST_NEXT_MINOR: '0'
   # Opt-out of testing next Major (Drupal 11.x).
   OPT_IN_TEST_NEXT_MAJOR: '0'

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -30,13 +30,12 @@ include:
 ################
 variables:
   # The 2.x branch of the module should run on 9.5 to maximum 10.2 but not upper.
-  CORE_PREVIOUS_STABLE: '10.0'
-  CORE_STABLE: '10.1'
-  CORE_NEXT_MINOR: '10.2'
-  CORE_SECURITY_PREVIOUS_MINOR: '10.1'
+  CORE_PREVIOUS_STABLE: '10.3'
+  CORE_STABLE: '10.4'
+  CORE_NEXT_MINOR: '10.5'
+  CORE_SECURITY_PREVIOUS_MINOR: '10.3'
   # The 2.x branch of the module requires PHP >=8.1, rather than core's >=7.4.
   CORE_PREVIOUS_PHP_MIN: '8.1'
-  CORE_PHP_MAX: '8.2'
 
   # Opt-in to testing previous Minor (Drupal 10.x).
   OPT_IN_TEST_CURRENT: '1'
@@ -46,8 +45,8 @@ variables:
   OPT_IN_TEST_PREVIOUS_MINOR: '1'
   # Opt-in to testing previous Major (Drupal 9.5.x).
   OPT_IN_TEST_PREVIOUS_MAJOR: '1'
-  # Opt-int of testing next Minor (Drupal 10.x).
-  OPT_IN_TEST_NEXT_MINOR: '1'
+  # Opt-int of testing next Minor (Drupal 10.5).
+  OPT_IN_TEST_NEXT_MINOR: '0'
   # Opt-out of testing next Major (Drupal 11.x).
   OPT_IN_TEST_NEXT_MAJOR: '0'
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-- fix support from 9.5.x to 10.2 maximum
+- fix support (tests fails) for 9.5.x to 10.2
 - add official stable support for drupal 10.3
 - add official stable support for drupal 10.4
 
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - remove legacy version annotation on docker-compose.yml
 
 ### Changed
-- change gitlab-ci in order to run tests for Drupal 9.5.x & 10.2.x but not for Drupal 10.3+
+- change gitlab-ci in order to run tests for Drupal 9.5.x & 10x but not for Drupal 11.x
 
 ## [2.3.0] - 2024-04-08
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - fix support from 9.5.x to 10.2 maximum
+- add official stable support for drupal 10.3
+- add official stable support for drupal 10.4
 
 ### Removed
 - remove legacy version annotation on docker-compose.yml

--- a/editor_advanced_image.info.yml
+++ b/editor_advanced_image.info.yml
@@ -1,8 +1,11 @@
 name: 'Editor Advanced Image'
 type: module
 description: 'Enhances the inline-image Dialog in D8 CKEditor.'
-core_version_requirement: ^9.5 || ^10
+core_version_requirement: ^9.5 || ^10.3
 package: CKEditor
 
 dependencies:
   - drupal:editor
+
+test_dependencies:
+  - drupal:ckeditor

--- a/editor_advanced_image.info.yml
+++ b/editor_advanced_image.info.yml
@@ -1,7 +1,7 @@
 name: 'Editor Advanced Image'
 type: module
 description: 'Enhances the inline-image Dialog in D8 CKEditor.'
-core_version_requirement: ^9.5 || ^10.3
+core_version_requirement: ^9.5 || ^10
 package: CKEditor
 
 dependencies:

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -7,3 +7,5 @@ parameters:
   ignoreErrors:
     # new static() is a best practice in Drupal, so we cannot fix that.
     - "#^Unsafe usage of new static#"
+  excludePaths:
+    - tests/src/Kernel/CKEditor4To5Upgrade/UpgradePathTest.php

--- a/tests/src/FunctionalJavascript/CKEditor4EditorAdvancedImageDialogTest.php
+++ b/tests/src/FunctionalJavascript/CKEditor4EditorAdvancedImageDialogTest.php
@@ -124,15 +124,6 @@ class CKEditor4EditorAdvancedImageDialogTest extends UiTestBase {
   }
 
   /**
-   * Tests the node add page is reachable.
-   */
-  public function testNodeAddPageReachable() {
-    $this->drupalLogin($this->adminUser);
-    $this->drupalGet('node/add/page');
-    $this->assertSession()->elementExists('css', 'form.node-page-form');
-  }
-
-  /**
    * Tests CKEditor button image still apprear, works & dialog open.
    */
   public function testImageBaseDialogWorks() {

--- a/tests/src/Kernel/CKEditor4To5Upgrade/UpgradePathTest.php
+++ b/tests/src/Kernel/CKEditor4To5Upgrade/UpgradePathTest.php
@@ -9,6 +9,422 @@ use Drupal\editor_advanced_image\Plugin\CKEditor5Plugin\EditorAdvancedImage;
 use Drupal\filter\Entity\FilterFormat;
 use Drupal\Tests\ckeditor5\Kernel\SmartDefaultSettingsTest;
 
+// phpcs:ignoreFile
+
+if (version_compare(\Drupal::VERSION, '10.3', '<')) {
+  class CrossCompatibleUpgradePath extends SmartDefaultSettingsTest {
+    /**
+     * {@inheritdoc}
+     */
+    public function provider() {
+      $expected_ckeditor5_toolbar = [
+        'items' => [
+          'bold',
+          'drupalInsertImage',
+        ],
+      ];
+
+      yield '<img title> + CKEditor 4 DrupalImage' => [
+        'format_id' => 'editor_advanced_image__title',
+        'filters_to_drop' => [],
+        'expected_ckeditor5_settings' => [
+          'toolbar' => $expected_ckeditor5_toolbar,
+          'plugins' => [
+            'ckeditor5_imageResize' => ['allow_resize' => TRUE],
+            'editor_advanced_image_image' => [
+              'disable_balloon' => FALSE,
+              'default_class' => '',
+              'enabled_attributes' => [
+                'title',
+              ],
+            ],
+          ],
+        ],
+        'expected_superset' => '',
+        'expected_fundamental_compatibility_violations' => [],
+        'expected_db_logs' => [],
+        'expected_messages' => [],
+      ];
+
+      yield '<img class> + CKEditor 4 DrupalImage' => [
+        'format_id' => 'editor_advanced_image__class',
+        'filters_to_drop' => [],
+        'expected_ckeditor5_settings' => [
+          'toolbar' => $expected_ckeditor5_toolbar,
+          'plugins' => [
+            'ckeditor5_imageResize' => ['allow_resize' => TRUE],
+            'editor_advanced_image_image' => [
+              'disable_balloon' => FALSE,
+              'default_class' => '',
+              'enabled_attributes' => [
+                'class',
+              ],
+            ],
+          ],
+        ],
+        'expected_superset' => '',
+        'expected_fundamental_compatibility_violations' => [],
+        'expected_db_logs' => [],
+        'expected_messages' => [],
+      ];
+
+      yield '<img id> + CKEditor 4 DrupalImage' => [
+        'format_id' => 'editor_advanced_image__id',
+        'filters_to_drop' => [],
+        'expected_ckeditor5_settings' => [
+          'toolbar' => $expected_ckeditor5_toolbar,
+          'plugins' => [
+            'ckeditor5_imageResize' => ['allow_resize' => TRUE],
+            'editor_advanced_image_image' => [
+              'disable_balloon' => FALSE,
+              'default_class' => '',
+              'enabled_attributes' => [
+                'id',
+              ],
+            ],
+          ],
+        ],
+        'expected_superset' => '',
+        'expected_fundamental_compatibility_violations' => [],
+        'expected_db_logs' => [],
+        'expected_messages' => [],
+      ];
+
+      yield 'None, just plain img + CKEditor 4 DrupalImage' => [
+        'format_id' => 'editor_advanced_image__none',
+        'filters_to_drop' => [],
+        'expected_ckeditor5_settings' => [
+          'toolbar' => [
+            'items' => [
+              'bold',
+              'drupalInsertImage',
+            ],
+          ],
+          'plugins' => [
+            'ckeditor5_imageResize' => ['allow_resize' => TRUE],
+            'editor_advanced_image_image' => EditorAdvancedImage::DEFAULT_CONFIGURATION,
+          ],
+        ],
+        'expected_superset' => '<img class>',
+        'expected_fundamental_compatibility_violations' => [],
+        'expected_db_logs' => [],
+        'expected_messages' => [
+          'warning' => [
+            'Updating to CKEditor 5 added support for some previously unsupported tags/attributes. A plugin introduced support for the following:   This attribute: <em class="placeholder"> class (for &lt;img&gt;)</em>; Additional details are available in your logs.',
+          ],
+        ],
+      ];
+
+      yield '<img FOO title class id BAR="baz"> + CKEditor 4 DrupalImage' => [
+        'format_id' => 'editor_advanced_image__all_and_more',
+        'filters_to_drop' => [],
+        'expected_ckeditor5_settings' => [
+          'toolbar' => [
+            'items' => [
+              'bold',
+              'drupalInsertImage',
+              'sourceEditing',
+            ],
+          ],
+          'plugins' => [
+            'ckeditor5_imageResize' => ['allow_resize' => TRUE],
+            'ckeditor5_sourceEditing' => [
+              'allowed_tags' => [
+                '<img foo bar="baz">',
+              ],
+            ],
+            'editor_advanced_image_image' => [
+              'disable_balloon' => FALSE,
+              'default_class' => 'foobar',
+              'enabled_attributes' => [
+                'class',
+                'id',
+                'title',
+              ],
+            ],
+          ],
+        ],
+        'expected_superset' => '',
+        'expected_fundamental_compatibility_violations' => [],
+        'expected_db_logs' => [
+          'status' => [
+            'As part of migrating to CKEditor 5, it was found that the <em class="placeholder">All and more</em> text format\'s HTML filters includes plugins that support the following tags, but not some of their attributes. To ensure these attributes remain supported, the following were added to the Source Editing plugin\'s <em>Manually editable HTML tags</em>: &lt;img foo bar=&quot;baz&quot;&gt;. The text format must be saved to make these changes active.',
+          ],
+        ],
+        'expected_messages' => [
+          'status' => [
+            'To maintain the capabilities of this text format, <a target="_blank" href="/admin/help/ckeditor5#migration-settings">the CKEditor 5 migration</a> did the following:  Added these tags/attributes to the Source Editing Plugin\'s <a target="_blank" href="/admin/help/ckeditor5#source-editing">Manually editable HTML tags</a> setting: &lt;img foo bar=&quot;baz&quot;&gt;. Additional details are available in your logs.',
+          ],
+        ],
+      ];
+
+      // Verify that none of the core test cases are broken; especially important
+      // for EditorAdvancedImage since it extends the behavior of Drupal core.
+      // @see Drupal\Tests\ckeditor5\Kernel\SmartDefaultSettingsTest
+      $formats_not_supporting_img = [
+        'cke4_stylescombo_span',
+        'filter_only__filter_html',
+        'restricted_html',
+        'cke4_plugins_with_settings',
+        'cke4_contrib_plugins_now_in_core',
+        'minimal_ckeditor_wrong_allowed_html',
+      ];
+      $full_html_configuration = [
+        'disable_balloon' => FALSE,
+        'default_class' => '',
+        'enabled_attributes' => array_keys(EditorAdvancedImage::SUPPORTED_ATTRIBUTES),
+      ];
+      sort($full_html_configuration['enabled_attributes']);
+
+      foreach (parent::provider() as $label => $case) {
+        // The `editor_advanced_image_image` plugin settings will appear for every
+        // upgraded text editor while editor_advanced_image is installed, as long
+        // as it has the `DrupalImage` button enabled in CKEditor 4.
+        if (!in_array($case['format_id'], $formats_not_supporting_img, TRUE)) {
+          $case['expected_superset'] .= ' <img class>';
+          $case['expected_superset'] = trim($case['expected_superset'], ' ');
+
+          // A Warning message will be triggered as <img> was not present on the
+          // HTML limited tag.
+          $case['expected_messages']['warning'][] = 'Updating to CKEditor 5 added support for some previously unsupported tags/attributes. A plugin introduced support for the following:   This attribute: <em class="placeholder"> class (for &lt;img&gt;)</em>; Additional details are available in your logs.';
+
+          // The previous warning is a bit different on basic_html_with_pre.
+          if ($case['format_id'] === 'basic_html_with_pre') {
+            $case['expected_messages']['warning'] = ['Updating to CKEditor 5 added support for some previously unsupported tags/attributes. A plugin introduced support for the following:   This attribute: <em class="placeholder"> class (for &lt;code&gt;, &lt;img&gt;)</em>; Additional details are available in your logs.'];
+          }
+
+          // The previous warning is a bit different on
+          // basic_html_with_alignable_p.
+          if ($case['format_id'] === 'basic_html_with_alignable_p') {
+            $case['expected_messages']['warning'] = ['Updating to CKEditor 5 added support for some previously unsupported tags/attributes. A plugin introduced support for the following:   This attribute: <em class="placeholder"> class (for &lt;h2&gt;, &lt;h3&gt;, &lt;h4&gt;, &lt;h5&gt;, &lt;h6&gt;, &lt;img&gt;)</em>; Additional details are available in your logs.'];
+          }
+
+          // Add the default Editor Advanced Image configuration excepted for
+          // full_html that must enable every Editor Advanced Image options.
+          $case['expected_ckeditor5_settings']['plugins']['editor_advanced_image_image'] = EditorAdvancedImage::DEFAULT_CONFIGURATION;
+          if ($case['format_id'] === 'full_html') {
+            $case['expected_ckeditor5_settings']['plugins']['editor_advanced_image_image'] = $full_html_configuration;
+            unset($case['expected_messages']['warning']);
+          }
+
+          // Reorder the plugins settings as we manually added Editor Advanced
+          // Image one.
+          ksort($case['expected_ckeditor5_settings']['plugins']);
+        }
+
+        yield $label => $case;
+      }
+    }
+  }
+} else {
+  class CrossCompatibleUpgradePath extends SmartDefaultSettingsTest
+  {
+      /**
+       * {@inheritdoc}
+       */
+      public static function provider()
+      {
+        $expected_ckeditor5_toolbar = [
+          'items' => [
+            'bold',
+            'drupalInsertImage',
+          ],
+        ];
+
+        yield '<img title> + CKEditor 4 DrupalImage' => [
+          'format_id' => 'editor_advanced_image__title',
+          'filters_to_drop' => [],
+          'expected_ckeditor5_settings' => [
+            'toolbar' => $expected_ckeditor5_toolbar,
+            'plugins' => [
+              'ckeditor5_imageResize' => ['allow_resize' => TRUE],
+              'editor_advanced_image_image' => [
+                'disable_balloon' => FALSE,
+                'default_class' => '',
+                'enabled_attributes' => [
+                  'title',
+                ],
+              ],
+            ],
+          ],
+          'expected_superset' => '',
+          'expected_fundamental_compatibility_violations' => [],
+          'expected_db_logs' => [],
+          'expected_messages' => [],
+        ];
+
+        yield '<img class> + CKEditor 4 DrupalImage' => [
+          'format_id' => 'editor_advanced_image__class',
+          'filters_to_drop' => [],
+          'expected_ckeditor5_settings' => [
+            'toolbar' => $expected_ckeditor5_toolbar,
+            'plugins' => [
+              'ckeditor5_imageResize' => ['allow_resize' => TRUE],
+              'editor_advanced_image_image' => [
+                'disable_balloon' => FALSE,
+                'default_class' => '',
+                'enabled_attributes' => [
+                  'class',
+                ],
+              ],
+            ],
+          ],
+          'expected_superset' => '',
+          'expected_fundamental_compatibility_violations' => [],
+          'expected_db_logs' => [],
+          'expected_messages' => [],
+        ];
+
+        yield '<img id> + CKEditor 4 DrupalImage' => [
+          'format_id' => 'editor_advanced_image__id',
+          'filters_to_drop' => [],
+          'expected_ckeditor5_settings' => [
+            'toolbar' => $expected_ckeditor5_toolbar,
+            'plugins' => [
+              'ckeditor5_imageResize' => ['allow_resize' => TRUE],
+              'editor_advanced_image_image' => [
+                'disable_balloon' => FALSE,
+                'default_class' => '',
+                'enabled_attributes' => [
+                  'id',
+                ],
+              ],
+            ],
+          ],
+          'expected_superset' => '',
+          'expected_fundamental_compatibility_violations' => [],
+          'expected_db_logs' => [],
+          'expected_messages' => [],
+        ];
+
+        yield 'None, just plain img + CKEditor 4 DrupalImage' => [
+          'format_id' => 'editor_advanced_image__none',
+          'filters_to_drop' => [],
+          'expected_ckeditor5_settings' => [
+            'toolbar' => [
+              'items' => [
+                'bold',
+                'drupalInsertImage',
+              ],
+            ],
+            'plugins' => [
+              'ckeditor5_imageResize' => ['allow_resize' => TRUE],
+              'editor_advanced_image_image' => EditorAdvancedImage::DEFAULT_CONFIGURATION,
+            ],
+          ],
+          'expected_superset' => '<img class>',
+          'expected_fundamental_compatibility_violations' => [],
+          'expected_db_logs' => [],
+          'expected_messages' => [
+            'warning' => [
+              'Updating to CKEditor 5 added support for some previously unsupported tags/attributes. A plugin introduced support for the following:   This attribute: <em class="placeholder"> class (for &lt;img&gt;)</em>; Additional details are available in your logs.',
+            ],
+          ],
+        ];
+
+        yield '<img FOO title class id BAR="baz"> + CKEditor 4 DrupalImage' => [
+          'format_id' => 'editor_advanced_image__all_and_more',
+          'filters_to_drop' => [],
+          'expected_ckeditor5_settings' => [
+            'toolbar' => [
+              'items' => [
+                'bold',
+                'drupalInsertImage',
+                'sourceEditing',
+              ],
+            ],
+            'plugins' => [
+              'ckeditor5_imageResize' => ['allow_resize' => TRUE],
+              'ckeditor5_sourceEditing' => [
+                'allowed_tags' => [
+                  '<img foo bar="baz">',
+                ],
+              ],
+              'editor_advanced_image_image' => [
+                'disable_balloon' => FALSE,
+                'default_class' => 'foobar',
+                'enabled_attributes' => [
+                  'class',
+                  'id',
+                  'title',
+                ],
+              ],
+            ],
+          ],
+          'expected_superset' => '',
+          'expected_fundamental_compatibility_violations' => [],
+          'expected_db_logs' => [
+            'status' => [
+              'As part of migrating to CKEditor 5, it was found that the <em class="placeholder">All and more</em> text format\'s HTML filters includes plugins that support the following tags, but not some of their attributes. To ensure these attributes remain supported, the following were added to the Source Editing plugin\'s <em>Manually editable HTML tags</em>: &lt;img foo bar=&quot;baz&quot;&gt;. The text format must be saved to make these changes active.',
+            ],
+          ],
+          'expected_messages' => [
+            'status' => [
+              'To maintain the capabilities of this text format, <a target="_blank" href="/admin/help/ckeditor5#migration-settings">the CKEditor 5 migration</a> did the following:  Added these tags/attributes to the Source Editing Plugin\'s <a target="_blank" href="/admin/help/ckeditor5#source-editing">Manually editable HTML tags</a> setting: &lt;img foo bar=&quot;baz&quot;&gt;. Additional details are available in your logs.',
+            ],
+          ],
+        ];
+
+        // Verify that none of the core test cases are broken; especially important
+        // for EditorAdvancedImage since it extends the behavior of Drupal core.
+        // @see Drupal\Tests\ckeditor5\Kernel\SmartDefaultSettingsTest
+        $formats_not_supporting_img = [
+          'cke4_stylescombo_span',
+          'filter_only__filter_html',
+          'restricted_html',
+          'cke4_plugins_with_settings',
+          'cke4_contrib_plugins_now_in_core',
+          'minimal_ckeditor_wrong_allowed_html',
+        ];
+        $full_html_configuration = [
+          'disable_balloon' => FALSE,
+          'default_class' => '',
+          'enabled_attributes' => array_keys(EditorAdvancedImage::SUPPORTED_ATTRIBUTES),
+        ];
+        sort($full_html_configuration['enabled_attributes']);
+
+        foreach (parent::provider() as $label => $case) {
+          // The `editor_advanced_image_image` plugin settings will appear for every
+          // upgraded text editor while editor_advanced_image is installed, as long
+          // as it has the `DrupalImage` button enabled in CKEditor 4.
+          if (!in_array($case['format_id'], $formats_not_supporting_img, TRUE)) {
+            $case['expected_superset'] .= ' <img class>';
+            $case['expected_superset'] = trim($case['expected_superset'], ' ');
+
+            // A Warning message will be triggered as <img> was not present on the
+            // HTML limited tag.
+            $case['expected_messages']['warning'][] = 'Updating to CKEditor 5 added support for some previously unsupported tags/attributes. A plugin introduced support for the following:   This attribute: <em class="placeholder"> class (for &lt;img&gt;)</em>; Additional details are available in your logs.';
+
+            // The previous warning is a bit different on basic_html_with_pre.
+            if ($case['format_id'] === 'basic_html_with_pre') {
+              $case['expected_messages']['warning'] = ['Updating to CKEditor 5 added support for some previously unsupported tags/attributes. A plugin introduced support for the following:   This attribute: <em class="placeholder"> class (for &lt;code&gt;, &lt;img&gt;)</em>; Additional details are available in your logs.'];
+            }
+
+            // The previous warning is a bit different on
+            // basic_html_with_alignable_p.
+            if ($case['format_id'] === 'basic_html_with_alignable_p') {
+              $case['expected_messages']['warning'] = ['Updating to CKEditor 5 added support for some previously unsupported tags/attributes. A plugin introduced support for the following:   This attribute: <em class="placeholder"> class (for &lt;h2&gt;, &lt;h3&gt;, &lt;h4&gt;, &lt;h5&gt;, &lt;h6&gt;, &lt;img&gt;)</em>; Additional details are available in your logs.'];
+            }
+
+            // Add the default Editor Advanced Image configuration excepted for
+            // full_html that must enable every Editor Advanced Image options.
+            $case['expected_ckeditor5_settings']['plugins']['editor_advanced_image_image'] = EditorAdvancedImage::DEFAULT_CONFIGURATION;
+            if ($case['format_id'] === 'full_html') {
+              $case['expected_ckeditor5_settings']['plugins']['editor_advanced_image_image'] = $full_html_configuration;
+              unset($case['expected_messages']['warning']);
+            }
+
+            // Reorder the plugins settings as we manually added Editor Advanced
+            // Image one.
+            ksort($case['expected_ckeditor5_settings']['plugins']);
+          }
+
+          yield $label => $case;
+        }
+      }
+    }
+}
+
 /**
  * @covers \Drupal\editor_advanced_image\Plugin\CKEditor4To5Upgrade\EditorAdvancedImage
  *
@@ -21,7 +437,7 @@ use Drupal\Tests\ckeditor5\Kernel\SmartDefaultSettingsTest;
  *
  * @requires module ckeditor5
  */
-class UpgradePathTest extends SmartDefaultSettingsTest {
+class UpgradePathTest extends CrossCompatibleUpgradePath {
 
   /**
    * {@inheritdoc}
@@ -34,11 +450,15 @@ class UpgradePathTest extends SmartDefaultSettingsTest {
    * {@inheritdoc}
    */
   protected function setUp(): void {
-    parent::setUp();
-
     if (version_compare(\Drupal::VERSION, '10', '<')) {
       $this->markTestSkipped('Upgrade path will only run properly on Drupal 10+ because of config sorting.');
     }
+
+    if (version_compare(\Drupal::VERSION, '10.2', '>')) {
+      $this->markTestSkipped('Cannot run CKEditor4 upgrade path to CKEditor 5 on Drupal later than 10.2.');
+    }
+
+    parent::setUp();
 
     // Create test FilterFormat config entities: one per option to test in
     // isolation, plus one to test with the default configuration (class attr
@@ -131,208 +551,4 @@ class UpgradePathTest extends SmartDefaultSettingsTest {
       'settings' => $cke4_settings,
     ])->setSyncing(TRUE)->save();
   }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function provider() {
-    $expected_ckeditor5_toolbar = [
-      'items' => [
-        'bold',
-        'drupalInsertImage',
-      ],
-    ];
-
-    yield '<img title> + CKEditor 4 DrupalImage' => [
-      'format_id' => 'editor_advanced_image__title',
-      'filters_to_drop' => [],
-      'expected_ckeditor5_settings' => [
-        'toolbar' => $expected_ckeditor5_toolbar,
-        'plugins' => [
-          'ckeditor5_imageResize' => ['allow_resize' => TRUE],
-          'editor_advanced_image_image' => [
-            'disable_balloon' => FALSE,
-            'default_class' => '',
-            'enabled_attributes' => [
-              'title',
-            ],
-          ],
-        ],
-      ],
-      'expected_superset' => '',
-      'expected_fundamental_compatibility_violations' => [],
-      'expected_db_logs' => [],
-      'expected_messages' => [],
-    ];
-
-    yield '<img class> + CKEditor 4 DrupalImage' => [
-      'format_id' => 'editor_advanced_image__class',
-      'filters_to_drop' => [],
-      'expected_ckeditor5_settings' => [
-        'toolbar' => $expected_ckeditor5_toolbar,
-        'plugins' => [
-          'ckeditor5_imageResize' => ['allow_resize' => TRUE],
-          'editor_advanced_image_image' => [
-            'disable_balloon' => FALSE,
-            'default_class' => '',
-            'enabled_attributes' => [
-              'class',
-            ],
-          ],
-        ],
-      ],
-      'expected_superset' => '',
-      'expected_fundamental_compatibility_violations' => [],
-      'expected_db_logs' => [],
-      'expected_messages' => [],
-    ];
-
-    yield '<img id> + CKEditor 4 DrupalImage' => [
-      'format_id' => 'editor_advanced_image__id',
-      'filters_to_drop' => [],
-      'expected_ckeditor5_settings' => [
-        'toolbar' => $expected_ckeditor5_toolbar,
-        'plugins' => [
-          'ckeditor5_imageResize' => ['allow_resize' => TRUE],
-          'editor_advanced_image_image' => [
-            'disable_balloon' => FALSE,
-            'default_class' => '',
-            'enabled_attributes' => [
-              'id',
-            ],
-          ],
-        ],
-      ],
-      'expected_superset' => '',
-      'expected_fundamental_compatibility_violations' => [],
-      'expected_db_logs' => [],
-      'expected_messages' => [],
-    ];
-
-    yield 'None, just plain img + CKEditor 4 DrupalImage' => [
-      'format_id' => 'editor_advanced_image__none',
-      'filters_to_drop' => [],
-      'expected_ckeditor5_settings' => [
-        'toolbar' => [
-          'items' => [
-            'bold',
-            'drupalInsertImage',
-          ],
-        ],
-        'plugins' => [
-          'ckeditor5_imageResize' => ['allow_resize' => TRUE],
-          'editor_advanced_image_image' => EditorAdvancedImage::DEFAULT_CONFIGURATION,
-        ],
-      ],
-      'expected_superset' => '<img class>',
-      'expected_fundamental_compatibility_violations' => [],
-      'expected_db_logs' => [],
-      'expected_messages' => [
-        'warning' => [
-          'Updating to CKEditor 5 added support for some previously unsupported tags/attributes. A plugin introduced support for the following:   This attribute: <em class="placeholder"> class (for &lt;img&gt;)</em>; Additional details are available in your logs.',
-        ],
-      ],
-    ];
-
-    yield '<img FOO title class id BAR="baz"> + CKEditor 4 DrupalImage' => [
-      'format_id' => 'editor_advanced_image__all_and_more',
-      'filters_to_drop' => [],
-      'expected_ckeditor5_settings' => [
-        'toolbar' => [
-          'items' => [
-            'bold',
-            'drupalInsertImage',
-            'sourceEditing',
-          ],
-        ],
-        'plugins' => [
-          'ckeditor5_imageResize' => ['allow_resize' => TRUE],
-          'ckeditor5_sourceEditing' => [
-            'allowed_tags' => [
-              '<img foo bar="baz">',
-            ],
-          ],
-          'editor_advanced_image_image' => [
-            'disable_balloon' => FALSE,
-            'default_class' => 'foobar',
-            'enabled_attributes' => [
-              'class',
-              'id',
-              'title',
-            ],
-          ],
-        ],
-      ],
-      'expected_superset' => '',
-      'expected_fundamental_compatibility_violations' => [],
-      'expected_db_logs' => [
-        'status' => [
-          'As part of migrating to CKEditor 5, it was found that the <em class="placeholder">All and more</em> text format\'s HTML filters includes plugins that support the following tags, but not some of their attributes. To ensure these attributes remain supported, the following were added to the Source Editing plugin\'s <em>Manually editable HTML tags</em>: &lt;img foo bar=&quot;baz&quot;&gt;. The text format must be saved to make these changes active.',
-        ],
-      ],
-      'expected_messages' => [
-        'status' => [
-          'To maintain the capabilities of this text format, <a target="_blank" href="/admin/help/ckeditor5#migration-settings">the CKEditor 5 migration</a> did the following:  Added these tags/attributes to the Source Editing Plugin\'s <a target="_blank" href="/admin/help/ckeditor5#source-editing">Manually editable HTML tags</a> setting: &lt;img foo bar=&quot;baz&quot;&gt;. Additional details are available in your logs.',
-        ],
-      ],
-    ];
-
-    // Verify that none of the core test cases are broken; especially important
-    // for EditorAdvancedImage since it extends the behavior of Drupal core.
-    // @see Drupal\Tests\ckeditor5\Kernel\SmartDefaultSettingsTest
-    $formats_not_supporting_img = [
-      'cke4_stylescombo_span',
-      'filter_only__filter_html',
-      'restricted_html',
-      'cke4_plugins_with_settings',
-      'cke4_contrib_plugins_now_in_core',
-      'minimal_ckeditor_wrong_allowed_html',
-    ];
-    $full_html_configuration = [
-      'disable_balloon' => FALSE,
-      'default_class' => '',
-      'enabled_attributes' => array_keys(EditorAdvancedImage::SUPPORTED_ATTRIBUTES),
-    ];
-    sort($full_html_configuration['enabled_attributes']);
-
-    foreach (parent::provider() as $label => $case) {
-      // The `editor_advanced_image_image` plugin settings will appear for every
-      // upgraded text editor while editor_advanced_image is installed, as long
-      // as it has the `DrupalImage` button enabled in CKEditor 4.
-      if (!in_array($case['format_id'], $formats_not_supporting_img, TRUE)) {
-        $case['expected_superset'] .= ' <img class>';
-        $case['expected_superset'] = trim($case['expected_superset'], ' ');
-
-        // A Warning message will be triggered as <img> was not present on the
-        // HTML limited tag.
-        $case['expected_messages']['warning'][] = 'Updating to CKEditor 5 added support for some previously unsupported tags/attributes. A plugin introduced support for the following:   This attribute: <em class="placeholder"> class (for &lt;img&gt;)</em>; Additional details are available in your logs.';
-
-        // The previous warning is a bit different on basic_html_with_pre.
-        if ($case['format_id'] === 'basic_html_with_pre') {
-          $case['expected_messages']['warning'] = ['Updating to CKEditor 5 added support for some previously unsupported tags/attributes. A plugin introduced support for the following:   This attribute: <em class="placeholder"> class (for &lt;code&gt;, &lt;img&gt;)</em>; Additional details are available in your logs.'];
-        }
-
-        // The previous warning is a bit different on
-        // basic_html_with_alignable_p.
-        if ($case['format_id'] === 'basic_html_with_alignable_p') {
-          $case['expected_messages']['warning'] = ['Updating to CKEditor 5 added support for some previously unsupported tags/attributes. A plugin introduced support for the following:   This attribute: <em class="placeholder"> class (for &lt;h2&gt;, &lt;h3&gt;, &lt;h4&gt;, &lt;h5&gt;, &lt;h6&gt;, &lt;img&gt;)</em>; Additional details are available in your logs.'];
-        }
-
-        // Add the default Editor Advanced Image configuration excepted for
-        // full_html that must enable every Editor Advanced Image options.
-        $case['expected_ckeditor5_settings']['plugins']['editor_advanced_image_image'] = EditorAdvancedImage::DEFAULT_CONFIGURATION;
-        if ($case['format_id'] === 'full_html') {
-          $case['expected_ckeditor5_settings']['plugins']['editor_advanced_image_image'] = $full_html_configuration;
-          unset($case['expected_messages']['warning']);
-        }
-
-        // Reorder the plugins settings as we manually added Editor Advanced
-        // Image one.
-        ksort($case['expected_ckeditor5_settings']['plugins']);
-      }
-
-      yield $label => $case;
-    }
-  }
-
 }


### PR DESCRIPTION
### 💬 Description
add official stable support for drupal 10.4

- [x] Update the "Unreleased" section of the `CHANGELOG.md` with [chan](https://github.com/geut/chan/tree/main/packages/chan)
