### PR TITLE
remove scanning CSS/JS with phpcs (deprecated and support will be removed in PHP_CodeSniffer 4.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- remove scanning CSS/JS with phpcs (deprecated and support will be removed in PHP_CodeSniffer 4.0)
 
 ## [3.0.1] - 2025-04-23
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,6 @@
   "description": "Enhances the inline-image Dialog in Drupal CKEditor.",
   "type": "drupal-module",
   "homepage": "https://www.drupal.org/project/editor_advanced_image",
-  "minimum-stability": "dev",
   "authors": [
     {
       "name": "Antistatique",
@@ -29,7 +28,7 @@
   },
   "license": "GPL-2.0-or-later",
   "require-dev": {
-    "drupal/coder": "^8.3.1"
+    "drupal/coder": "^8.3"
   },
   "config": {
     "allow-plugins": {

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -6,7 +6,10 @@
   <arg name="basepath" value="."/>
   <arg name="cache" value=".phpcs-cache"/>
   <arg name="colors"/>
-  <arg name="extensions" value="php,module,inc,install,test,profile,theme,css,info,txt"/>
+  <arg name="extensions" value="php,inc,module,install,info,test,profile,theme"/>
+
+  <!-- Set up ignores. -->
+  <arg name="ignore" value="*.js,*.css"/>
 
   <exclude-pattern>*\.(md|info\.yml)$</exclude-pattern>>
   <exclude-pattern>*/vendor/*</exclude-pattern>>
@@ -15,4 +18,3 @@
   <rule ref="./vendor/drupal/coder/coder_sniffer/Drupal"/>
   <rule ref="./vendor/drupal/coder/coder_sniffer/DrupalPractice"/>
 </ruleset>
-


### PR DESCRIPTION
### 💬 Description
remove scanning CSS/JS with phpcs (deprecated and support will be removed in PHP_CodeSniffer 4.0)