### PR TITLE
add official support of drupal 10.6 & 11.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        drupal_version: ['10.5', '10.6' '11.2', '11.3']
+        drupal_version: ['10.5', '10.6', '11.2', '11.3']
         module: ['editor_advanced_image']
         experimental: [ false ]
 #         include:
@@ -43,7 +43,7 @@ jobs:
 
     strategy:
       matrix:
-        drupal_version: ['10.5', '10.6' '11.2', '11.3']
+        drupal_version: ['10.5', '10.6', '11.2', '11.3']
         module: ['editor_advanced_image']
         experimental: [ false ]
 #         include:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,16 @@ jobs:
 
     strategy:
       matrix:
-        drupal_version: ['10.5', '11.2']
+        drupal_version: ['10.5', '10.6' '11.2', '11.3']
         module: ['editor_advanced_image']
         experimental: [ false ]
+#         include:
+#           - drupal_version: '10.6'
+#             module: 'loco_translate'
+#             experimental: true
+#           - drupal_version: '11.4'
+#             module: 'loco_translate'
+#             experimental: true
 
     steps:
       - uses: actions/checkout@v6
@@ -36,9 +43,16 @@ jobs:
 
     strategy:
       matrix:
-        drupal_version: ['10.5', '11.2']
+        drupal_version: ['10.5', '10.6' '11.2', '11.3']
         module: ['editor_advanced_image']
         experimental: [ false ]
+#         include:
+#           - drupal_version: '10.6'
+#             module: 'loco_translate'
+#             experimental: true
+#           - drupal_version: '11.4'
+#             module: 'loco_translate'
+#             experimental: true
 
     steps:
       - uses: actions/checkout@v6
@@ -65,7 +79,7 @@ jobs:
 
     strategy:
       matrix:
-        drupal_version: ['10.5']
+        drupal_version: ['10.6']
         module: ['editor_advanced_image']
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- add official support of drupal 11.3
+- add official support of drupal 10.6
 
 ## [3.1.1] - 2025-10-06
 ### Fixed

--- a/tests/src/FunctionalJavascript/CKEditor5EditorAdvancedImageDialogTest.php
+++ b/tests/src/FunctionalJavascript/CKEditor5EditorAdvancedImageDialogTest.php
@@ -203,7 +203,7 @@ class CKEditor5EditorAdvancedImageDialogTest extends WebDriverTestBase {
     $this->drupalGet($this->testNode->toUrl('edit-form'));
     $this->waitForEditor();
     $assert_session = $this->assertSession();
-    $img = $assert_session->waitForElementVisible('css', '.ck-content img', 1000);
+    $img = $assert_session->waitForElementVisible('css', '.ck-widget.image', 1000);
     $img->click();
     $eai_button = $this->getBalloonButton('Editor Advanced Image');
     $eai_button->click();


### PR DESCRIPTION
### 💬 Description
add official support of drupal 10.6 & 11.3

- [x] Update the "Unreleased" section of the `CHANGELOG.md` with [chan](https://github.com/geut/chan/tree/main/packages/chan)
